### PR TITLE
feat(admin-export-donations): Added more details to the export file

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -406,8 +406,8 @@ const getDonationList = async (req, res) => {
   try {
     const donations = await donationModel
       .find()
-      .populate("userId", "fullname email contact address fatherName") // Populates the user who made the donation (the father)
-      .populate("donatedFor", "fullname") // CORRECT: Populates the child's document using the 'donatedFor' field
+      .populate("userId", "_id fullname email contact address fatherName gender") // Populates the user who made the donation (the father)
+      .populate("donatedFor", "fullname gender") // CORRECT: Populates the child's document using the 'donatedFor' field
       .sort({ createdAt: -1 });
 
     res.json({


### PR DESCRIPTION
* Admin API to get donation list is updated to include `gender` attribute
* Admin donations list export file includes following additional fields
  * `Date` - It will have date of donation
  * `User Ref Number` - It is _id of the user to identify multiple donations made by the user
  * `Profile Name` - Name followed by father's name
  * `Mobile Number`
  * `Email Address`
  * `Donated For` - It will either be `self` or `child`
  * `Donated For Name` - Name followed by father's name or relation name
  * `Receipt #` - Donation receipt number
  * `Category` - Donation category
  * `Number` - Quantity
  * `Amount` - Total donation amount in a category
  * `Prasad Collection Mode` - It will be either `Local Pickup` or `Courier` derived based on the postal address held against donation
  * `Courier Address` - Postal address from donation
  * `Prasad Packet` - Number of packets where applicable
  * `Prasad Weight` - It will be `-` if prasad collection mode is `Courier`, otherwise weight of prasad